### PR TITLE
Removing the profile identity from the yaml file

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,6 @@ service: books-api
 provider:
   name: aws
   runtime: nodejs18.x
-  profile: serverlessUser
   region: us-east-1
   iamRoleStatements:
     - Effect: Allow


### PR DESCRIPTION
since we are not using the serverless creds, i have removed the profile config to allow for the use of the actions creds